### PR TITLE
[Frontend] Sign in UI and authentication

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,5 +2,6 @@ node_modules
 # Keep environment variables out of version control
 .env
 node_modules
+package-lock.json
 /generated/prisma
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,7 +26,7 @@ function App() {
       <Routes>
         <Route path="/" element={<SignIn />} />
         <Route path="signUp" element={<SignUp />} />
-        <Route path="homepage" element={<Homepage />} />
+        <Route path="/homepage" element={<Homepage />} />
       </Routes>
     </>
   );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
 import "./App.css";
+import { BASE_URL } from "./data/data";
 import SignIn from "./SignIn";
 import SignUp from "./SignUp";
+import Homepage from "./Homepage";
 import { Routes, Route } from "react-router-dom";
 
 function App() {
-  const BASE_URL = "http://localhost:4500";
+  
   function navigate(url) {
     window.location.href = url;
   }
@@ -21,16 +23,17 @@ function App() {
 
   return (
     <>
-      <button type="button" onClick={() => auth()}>
-        Sign in
-      </button>
       <Routes>
         <Route path="/" element={<SignIn />} />
         <Route path="signUp" element={<SignUp />} />
-        <Route />
+        <Route path="homepage" element={<Homepage />} />
       </Routes>
     </>
   );
 }
 
 export default App;
+// TODO: WORKING ON THIS LATER 
+// <button type="button" onClick={() => auth()}>
+//         Google Sign in
+//       </button>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,7 +33,3 @@ function App() {
 }
 
 export default App;
-// TODO: WORKING ON THIS LATER 
-// <button type="button" onClick={() => auth()}>
-//         Google Sign in
-//       </button>

--- a/frontend/src/Homepage.jsx
+++ b/frontend/src/Homepage.jsx
@@ -1,0 +1,6 @@
+export default function Homepage(){
+    return(
+        // TODO: Homepage
+        <></>
+    )
+}

--- a/frontend/src/SignIn.css
+++ b/frontend/src/SignIn.css
@@ -1,0 +1,58 @@
+*{
+    margin: 0;
+    padding: 0;
+}
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+.SignUp-div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-family: Arial, Helvetica, sans-serif;
+  gap: 20px;
+}
+.sign-in-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+}
+.SignUp-div h1{
+    font-size: 50px;
+    color:#113f67 ;
+}
+.SignUp-div h3{
+    font-size: 30px;
+}
+.sign-in-form input {
+  padding: 10px 80px;
+}
+.sign-in-form input[type="text"]::placeholder {
+  text-align: center;
+  font-size: larger;
+}
+.sign-in-form input[type="password"]::placeholder {
+  text-align: center;
+  font-size: larger;
+}
+
+.sign-in-form button {
+  padding: 10px;
+  border-radius: 10px;
+  border: none;
+  background-color: #5585b5;
+  color: white;
+  cursor: pointer;
+  font-size: large;
+}
+.sign-up {
+  border: none;
+  background-color: white;
+  color: black;
+  cursor: pointer;
+  font-size: large;
+}

--- a/frontend/src/SignIn.jsx
+++ b/frontend/src/SignIn.jsx
@@ -1,16 +1,16 @@
 import { Link } from "react-router-dom";
 import { useState } from "react";
 import { BASE_URL } from "./data/data";
-import { Navigate } from 'react-router-dom';
-import './SignIn.css'
+import { useNavigate } from "react-router-dom";
+import "./SignIn.css";
 
 export default function SignIn() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-
+  const navigate = useNavigate();
   async function handleSubmit(e) {
-    setPassword("")
-    setUsername("")
+    setPassword("");
+    setUsername("");
     e.preventDefault();
     const formData = { username, password };
 
@@ -20,18 +20,17 @@ export default function SignIn() {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(formData)
+        body: JSON.stringify(formData),
       });
       if (res.ok) {
         const data = await res.json();
-       <Navigate to="/homepage" />
-      }
-      else{
+        navigate("/homepage", { replace: true });
+      } else {
         const data = await res.json();
-        alert(data.message)
+        alert(data.message);
       }
     } catch (error) {
-         console.error("Error:", error);
+      console.error("Error:", error);
     }
   }
 
@@ -40,25 +39,25 @@ export default function SignIn() {
       <h1>Show GraM</h1>
       <h3>Sign in</h3>
       <div>
-         <form className="sign-in-form" onSubmit={(e) => handleSubmit(e)}>
-        <input
-          type="text"
-          value={username}
-          placeholder="Username"
-          required
-          onChange={(e) => setUsername(e.target.value)}
-        />
-        <input
-          type="password"
-          value={password}
-          placeholder="password"
-          required
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button type="submit">Sign In</button>
-      </form>
+        <form className="sign-in-form" onSubmit={(e) => handleSubmit(e)}>
+          <input
+            type="text"
+            value={username}
+            placeholder="Username"
+            required
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <input
+            type="password"
+            value={password}
+            placeholder="password"
+            required
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button type="submit">Sign In</button>
+        </form>
       </div>
-     
+
       <Link to={"signUp"}>
         <button className="sign-up">Sign up</button>
       </Link>

--- a/frontend/src/SignIn.jsx
+++ b/frontend/src/SignIn.jsx
@@ -1,21 +1,46 @@
 import { Link } from "react-router-dom";
 import { useState } from "react";
-
+import { BASE_URL } from "./data/data";
+import { Navigate } from 'react-router-dom';
+import './SignIn.css'
 
 export default function SignIn() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
 
   async function handleSubmit(e) {
-    e.preventDefault()
-  
-}
+    setPassword("")
+    setUsername("")
+    e.preventDefault();
+    const formData = { username, password };
+
+    try {
+      const res = await fetch(`${BASE_URL}/login`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData)
+      });
+      if (res.ok) {
+        const data = await res.json();
+       <Navigate to="/homepage" />
+      }
+      else{
+        const data = await res.json();
+        alert(data.message)
+      }
+    } catch (error) {
+         console.error("Error:", error);
+    }
+  }
 
   return (
-    <div>
-      <h1>Movie Gran</h1>
+    <div className="SignUp-div">
+      <h1>Show GraM</h1>
       <h3>Sign in</h3>
-      <form onSubmit={(e) => (handleSubmit(e))} >
+      <div>
+         <form className="sign-in-form" onSubmit={(e) => handleSubmit(e)}>
         <input
           type="text"
           value={username}
@@ -32,8 +57,10 @@ export default function SignIn() {
         />
         <button type="submit">Sign In</button>
       </form>
+      </div>
+     
       <Link to={"signUp"}>
-        <button>Sign up</button>
+        <button className="sign-up">Sign up</button>
       </Link>
     </div>
   );

--- a/frontend/src/data/data.js
+++ b/frontend/src/data/data.js
@@ -1,0 +1,1 @@
+export const BASE_URL = "http://localhost:4500";


### PR DESCRIPTION
Added styling to the sign in page and added a navigation to homepage while preventing users from going back after successful login using  navigate("/homepage", { replace: true }). Below is the current outlook on the page.  First image shows the sign up page , second image shows unsuccessful login, last page shows change in url navigating to homepage upon successful login
![Screenshot 2025-06-25 at 3 51 44 PM](https://github.com/user-attachments/assets/325311fe-ecc8-418a-8f27-e6e394b4a48d)
![Screenshot 2025-06-25 at 3 52 16 PM](https://github.com/user-attachments/assets/a9532cae-ed92-4db1-baaa-be5802177e93)
![Screenshot 2025-06-25 at 3 52 39 PM](https://github.com/user-attachments/assets/8fe1d073-3614-488f-b173-94c79361b417)




