### PR TITLE
[TC2#][Backend] modified POST /comment endpoint to update both Word table and in-memory hashmap on user comment creation and added function to populate hashmap on server reload.

### DIFF
--- a/backend/clean-string/cleanString.js
+++ b/backend/clean-string/cleanString.js
@@ -11,6 +11,7 @@ export function removePunctuation(str) {
 
 function checkPunctuation(char) {
     const punctuation = '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~';
+    // todo: implement set for punctuations for fast lookups and also account for more ascii chars.
     return punctuation.includes(char);
 }
 

--- a/backend/clean-string/cleanString.js
+++ b/backend/clean-string/cleanString.js
@@ -1,0 +1,16 @@
+export function removePunctuation(str) {
+    let result = '';
+    for (let i = 0; i < str.length; i++) {
+        let character = str.charAt(i);
+        if (!checkPunctuation(character)) {
+            result += character;
+        }
+    }
+    return result;
+}
+
+function checkPunctuation(char) {
+    const punctuation = '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~';
+    return punctuation.includes(char);
+}
+

--- a/backend/index.js
+++ b/backend/index.js
@@ -7,6 +7,7 @@ import { OAuth2Client } from "google-auth-library";
 import { getUserData } from "./auth-function/getUserData.js";
 import session from "express-session";
 import { sortComment } from "./sort-function/sortComment.js";
+import { populateWordMap } from "./populate-hashmap/populateWordMap.js";
 
 dotenv.config();
 const app = express();
@@ -40,17 +41,6 @@ app.use(
   })
 );
 const wordMap = {};
-async function populateWordMap() {
-  try {
-    const allWords = await prisma.word.findMany();
-
-    for (const entry of allWords) {
-      wordMap[entry.word] = [...entry.commentIds];
-    }
-  } catch (error) {
-    // TODO:
-  }
-}
 
 const HttpStatus = {
   OK: 200,
@@ -381,5 +371,5 @@ app.get("/me", (req, res) => {
   }
 });
 
-await populateWordMap();
+await populateWordMap(wordMap);;
 app.listen(PORT, console.log(`Server running on http://localhost:${PORT}`));

--- a/backend/index.js
+++ b/backend/index.js
@@ -361,7 +361,7 @@ app.post("/comment", isAuthenticated, async (req, res) => {
         wordMap[word].push(newComment.id);
       }
     }
-    res.status(HttpStatus.OK).json(wordMap);
+    res.status(HttpStatus.OK).json(newComment);
   } catch (error) {
     res
       .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/backend/index.js
+++ b/backend/index.js
@@ -48,6 +48,7 @@ async function populateWordMap() {
       wordMap[entry.word] = [...entry.commentIds];
     }
   } catch (error) {
+    // TODO:
   }
 }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -8,6 +8,7 @@ import { getUserData } from "./auth-function/getUserData.js";
 import session from "express-session";
 import { sortComment } from "./sort-function/sortComment.js";
 import { populateWordMap } from "./populate-hashmap/populateWordMap.js";
+import { removePunctuation } from "./clean-string/cleanString.js";
 
 dotenv.config();
 const app = express();
@@ -319,8 +320,9 @@ app.post("/comment", isAuthenticated, async (req, res) => {
       },
     });
 
-    // case-insensitive, split, remove punctuation and  empty strings and 
-    const words = message.toLowerCase().split(/\W+/).filter(Boolean);
+    // case-insensitive, split, remove punctuation and  empty strings and
+    const cleanedWord = removePunctuation(message);
+    const words = cleanedWord.toLowerCase().split(" ").filter(Boolean);
 
     // get unique words
     const uniqueWords = new Set(words);
@@ -346,7 +348,7 @@ app.post("/comment", isAuthenticated, async (req, res) => {
         });
       }
       // Update in-memory hashmap
-       if (!wordMap[word]) {
+      if (!wordMap[word]) {
         wordMap[word] = [newComment.id];
       } else {
         wordMap[word].push(newComment.id);
@@ -371,5 +373,5 @@ app.get("/me", (req, res) => {
   }
 });
 
-await populateWordMap(wordMap);;
+await populateWordMap(wordMap);
 app.listen(PORT, console.log(`Server running on http://localhost:${PORT}`));

--- a/backend/populate-hashmap/populateWordMap.js
+++ b/backend/populate-hashmap/populateWordMap.js
@@ -1,0 +1,14 @@
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+
+export async function populateWordMap(wordMap) {
+  try {
+    const allWords = await prisma.word.findMany();
+
+    for (const entry of allWords) {
+      wordMap[entry.word] = [...entry.commentIds];
+    }
+  } catch (error) {
+   // TODO:
+  }
+}


### PR DESCRIPTION
**Description**
modified POST /comment endpoint to update both Word table and in-memory hashmap with unique words as keys and array of commentId as values upon user comment creation with added functionality to populate hashmap on server reload/restart.
Later PRs would be working on implementing /search endpoint for comments

**Milestone**
This feature works towards multi search functionality(TC2)

**TEST**
Image 1 shows hashmap details when user creates a comment
Image 2 shows hashmap details when user creates comment including punctuation
Image 3 shows hashmap on server restart
<img width="912" height="583" alt="Screenshot 2025-07-15 at 10 09 01 AM" src="https://github.com/user-attachments/assets/9b819a41-0f3b-4dc1-bb77-d9a295f3de52" />
<img width="910" height="617" alt="Screenshot 2025-07-15 at 10 09 47 AM" src="https://github.com/user-attachments/assets/4cc49c79-61ea-4d5a-9d8c-8cd2b148f076" />
<img width="384" height="450" alt="Screenshot 2025-07-15 at 10 50 03 AM" src="https://github.com/user-attachments/assets/8774d556-e582-43c1-b6bf-e13480d4b23d" />
