### PR TITLE
[Render] casing fix for components file name

### DIFF
--- a/frontend/src/Movielist.jsx
+++ b/frontend/src/Movielist.jsx
@@ -1,6 +1,6 @@
 import MovieCard from "./MovieCard";
 import { Link } from "react-router-dom";
-import "./Movielist.css";
+import "./MovieList.css";
 
 export default function MovieList({ moviesToshow }) {
   return (


### PR DESCRIPTION
Working on casing for components file name where filesystem is case-insensitive but case-preserving 