### PR TITLE
[STRETCH][DATABASE] Added spoiler field to comment table

### DIFF
--- a/backend/prisma/migrations/20250724225833_added_spoiler_field/migration.sql
+++ b/backend/prisma/migrations/20250724225833_added_spoiler_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN     "isSpoiler" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -32,6 +32,7 @@ model Comment {
   createdAt DateTime @default(now())
   upVotes   Int      @default(0)
   downVotes Int      @default(0)
+  isSpoiler Boolean  @default(false)
   votes     Vote[]
 }
 


### PR DESCRIPTION
**Description**
I added spoiler field to comment table for users to be able to add spoilers to a comment. Next PR would be working backend inclusion of spoiler when creating comment. 

**Milestone**
This works towards stretch features. 

**Test**
<img width="480" height="453" alt="Screenshot 2025-07-24 at 4 03 39 PM" src="https://github.com/user-attachments/assets/e744883d-eae1-442f-aa79-6ce1ad33eac2" />


