### PR TITLE
[STRETCH][BACKEND] Added spoiler field to req body parameters 

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -293,13 +293,14 @@ app.patch(
 
 // post a comment
 app.post("/comment", isAuthenticated, async (req, res) => {
-  const { message, movieId } = req.body;
+  const { message, movieId, isSpoiler } = req.body;
   try {
     const newComment = await prisma.comment.create({
       data: {
         message,
         movieId,
         userId: req.session.userId,
+        isSpoiler,
       },
     });
 

--- a/backend/prisma/migrations/20250724225833_added_spoiler_field/migration.sql
+++ b/backend/prisma/migrations/20250724225833_added_spoiler_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN     "isSpoiler" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -32,6 +32,7 @@ model Comment {
   createdAt DateTime @default(now())
   upVotes   Int      @default(0)
   downVotes Int      @default(0)
+  isSpoiler Boolean  @default(false)
   votes     Vote[]
 }
 


### PR DESCRIPTION
**Description**
 Added spoiler field to req body parameters. Next PR would be working frontend implementation.

**Milestone**
Feature works towards stretch feature to mark comment as spoilers.

Test
Spoiler set to TRUE
<img width="935" height="468" alt="Screenshot 2025-07-25 at 1 34 56 PM" src="https://github.com/user-attachments/assets/e05b97d7-3f50-47a4-8a95-d91d9310adb8" />

Default value
<img width="913" height="338" alt="Screenshot 2025-07-25 at 1 35 40 PM" src="https://github.com/user-attachments/assets/f44a4795-8b4f-4cd8-8754-23ccb3ab9b07" />


